### PR TITLE
Use "Software" rather than "Server" in nav links.

### DIFF
--- a/about-network.md
+++ b/about-network.md
@@ -9,7 +9,7 @@ classes: about
 
 <div class="buttons">
     <!-- <a class="button" href="/">Landing Page</a> -->
-    <a class="button" href="/about.html">Server</a>
+    <a class="button" href="/about.html">Software</a>
     <a class="button" href="#">Network</a>
 </div>
 

--- a/about.md
+++ b/about.md
@@ -9,7 +9,7 @@ classes: about
 
 <div class="buttons">
     <!-- <a class="button" href="/">Landing Page</a> -->
-    <a class="button" href="#">Server</a>
+    <a class="button" href="#">Software</a>
     <a class="button" href="/about-network.html">Network</a>
 </div>
 


### PR DESCRIPTION
This reflects the language on the landing page, and is a lot
less confusing imho (if you're looking at the network page then
it's not clear that "server" means "server software" rather than
"one particular server in the network" type thing)