### PR TITLE
Make the logo responsive on smaller screens

### DIFF
--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -3,7 +3,7 @@ layout: default
 ---
 <div>
     <a class="logo" href="/">
-        <img src="/img/{% if page.logo %}{{ page.logo }}{% elsif layout.logo %}{{ layout.logo }}{% else %}ergo-logo-dark-server.svg{% endif %}" title="Ergo IRC Server">
+        <img alt="Ergo Logo" src="/img/{% if page.logo %}{{ page.logo }}{% elsif layout.logo %}{{ layout.logo }}{% else %}ergo-logo-dark-server.svg{% endif %}" title="Ergo IRC Server">
     </a>
 
     <div class="buttons">

--- a/css/screen.scss
+++ b/css/screen.scss
@@ -38,6 +38,7 @@ body.about {
       text-align: center;
       padding: 3em 0 2em;
       img {
+        max-width: 95%;
         height: 10em;
       }
     }
@@ -92,6 +93,7 @@ body.homepage {
     text-align: center;
     padding-bottom: 1.7em;
     img {
+      max-width: 95%;
       margin: 0 auto;
       height: 10em;
     }


### PR DESCRIPTION
added alt attribute and max-width to the logo.

On my phone (and on some available FF responsive design presets) the logo will have x overflow, making the entire page sideways scrollable.

![oldergo](https://github.com/ergochat/site/assets/153449000/39425cac-e42b-4e9e-9dbf-ced9b990df66)

I thought 95% looks good but I can change if it there is a style guide / it doesnt look good. 

![newergo](https://github.com/ergochat/site/assets/153449000/61db7085-a34a-4347-84b6-efe77498631e)